### PR TITLE
feat: allow modlist autoblocking without logging in

### DIFF
--- a/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
+++ b/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
@@ -5,6 +5,7 @@
   import type { QueryObserverResult } from '@tanstack/svelte-query'
   import type { ModListSubscribeResponse } from '@mass-block-twitter/server'
   import { navigate } from '$lib/components/logic/router'
+  import { t } from '$lib/i18n';
 
   const {
     query,
@@ -23,7 +24,7 @@
   {:else if query.error}
     <QueryError description={query.error.message} />
   {:else if query.data?.length === 0}
-    <p class="text-muted-foreground">No subscribed modlists</p>
+    <p class="text-muted-foreground">{t('modlists.subscribed.noSubscribed')}</p>
   {:else}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {#each query.data ?? [] as list (list.id)}

--- a/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
+++ b/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
@@ -22,6 +22,8 @@
     <QueryLoading />
   {:else if query.error}
     <QueryError description={query.error.message} />
+  {:else if query.data?.length === 0}
+    <p class="text-muted-foreground">No subscribed modlists</p>
   {:else}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {#each query.data ?? [] as list (list.id)}

--- a/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
+++ b/packages/plugin/src/entrypoints/content/pages/modlists/components/ModLists.svelte
@@ -24,7 +24,7 @@
   {:else if query.error}
     <QueryError description={query.error.message} />
   {:else if query.data?.length === 0}
-    <p class="text-muted-foreground">{t('modlists.subscribed.noSubscribed')}</p>
+    <p class="text-muted-foreground">{$t('modlists.subscribed.noSubscribed')}</p>
   {:else}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {#each query.data ?? [] as list (list.id)}

--- a/packages/plugin/src/entrypoints/content/pages/modlists/page.svelte
+++ b/packages/plugin/src/entrypoints/content/pages/modlists/page.svelte
@@ -31,10 +31,6 @@
     navigate(`/modlists/created`)
   }
   async function onGotoSubscribed() {
-    if (!authInfo.value) {
-      toast.info($t('modlists.toast.login.subscribed'))
-      return
-    }
     navigate('/modlists/subscribe')
   }
 </script>

--- a/packages/plugin/src/i18n/en-US.json
+++ b/packages/plugin/src/i18n/en-US.json
@@ -48,6 +48,8 @@
   "account.logout.success": "Logged out",
   "account.logout.failed": "Logout failed",
   "account.upgrade.title": "Upgrade",
+  "account.login.toast.subscribeLocal.failed": "Failed to subscribe to previously locally subscribed modlist {modlistId}",
+
 
   "settings.title": "Settings",
   "settings.appearance.title": "Appearance",
@@ -152,7 +154,7 @@
   "modlists.nav.created": "Created",
   "modlists.nav.subscribed": "Subscribed",
   "modlists.toast.login.created": "Please login to view your created modlists",
-  "modlists.toast.login.subscribed": "Please login to view your subscribed modlists",
+  "modlists.subscribed.noSubscribed": "No subscribed modlists",
   "modlists.creator.title": "New Moderation List",
   "modlists.creator.toast.limit.title": "You have reached the maximum number of moderation lists.",
   "modlists.creator.toast.limit.description": "Please upgrade to Pro to create unlimited moderation lists.",

--- a/packages/plugin/src/i18n/zh-CN.json
+++ b/packages/plugin/src/i18n/zh-CN.json
@@ -149,7 +149,6 @@
   "modlists.nav.created": "已创建",
   "modlists.nav.subscribed": "已订阅",
   "modlists.toast.login.created": "请登录以查看你创建的审核列表",
-  "modlists.toast.login.subscribed": "请登录以查看你订阅的审核列表",
   "modlists.creator.error.userId": "未找到 Twitter 用户 ID，请重新登录。",
   "modlists.creator.error.userNotFound": "未找到用户，请重新登录。",
 

--- a/packages/plugin/src/lib/components/layout/AuthButton.svelte
+++ b/packages/plugin/src/lib/components/layout/AuthButton.svelte
@@ -47,7 +47,7 @@
           },
         )
         if (!resp.ok) {
-          toast.error(`Failed to subscribe to previously locally subscribed modlist ${modlistId}`)
+                toast.error($t('account.login.toast.subscribeLocal.failed', {values: {modlistId}}))
         }
       }
       queryClient.refetchQueries()

--- a/packages/plugin/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/packages/plugin/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -32,7 +32,7 @@
 	import { cn } from "$lib/utils.js";
 	import { mergeProps, type WithElementRef, type WithoutChildrenOrChild } from "bits-ui";
 	import type { ComponentProps, Snippet } from "svelte";
-	import type { HTMLAttributes } from "svelte/elements";
+	import type { HTMLAttributes, HTMLButtonAttributes } from "svelte/elements";
 	import { useSidebar } from "./context.svelte.js";
 
 	let {
@@ -46,7 +46,7 @@
 		tooltipContent,
 		tooltipContentProps,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+	}: WithElementRef<HTMLButtonAttributes, HTMLButtonElement> & {
 		isActive?: boolean;
 		variant?: SidebarMenuButtonVariant;
 		size?: SidebarMenuButtonSize;

--- a/packages/plugin/src/lib/content.ts
+++ b/packages/plugin/src/lib/content.ts
@@ -13,9 +13,8 @@ import { ModListSubscribedUsersKey } from './shared'
 import { crossFetch } from './query'
 import { dbApi } from './db'
 import { chunk } from 'lodash-es'
-import { getSettings } from './settings'
 import * as localModlistSubscriptions from '$lib/localModlistSubscriptions'
-import { ModListIdsResponse } from 'node_modules/@mass-block-twitter/server/src/routes/modlists'
+import { type ModListIdsResponse } from '@mass-block-twitter/server'
 
 export async function refreshModListSubscribedUsers(
   force?: boolean,

--- a/packages/plugin/src/lib/localModlistSubscriptions.ts
+++ b/packages/plugin/src/lib/localModlistSubscriptions.ts
@@ -1,26 +1,26 @@
 import { ModListSubscribeRequest } from "@mass-block-twitter/server";
-
-
+import { get, set, del, entries } from "idb-keyval";
 
 export async function setSubscription(modListId: string, action: ModListSubscribeRequest['action']) {
-  localStorage.setItem(`rxliuli:modlist:${modListId}:action`, action)
+  await set(`rxliuli:modlist:${modListId}:action`, action);
 }
+
 export async function removeSubscription(modListId: string) {
-  localStorage.removeItem(`rxliuli:modlist:${modListId}:action`)
+  await del(`rxliuli:modlist:${modListId}:action`);
 }
 
 export async function getSubscription(modListId: string): Promise<ModListSubscribeRequest['action'] | null> {
-  return localStorage.getItem(`rxliuli:modlist:${modListId}:action`) as ModListSubscribeRequest['action'] | null
+  return await get(`rxliuli:modlist:${modListId}:action`) as ModListSubscribeRequest['action'] | null;
 }
 
 export async function getAllSubscriptions(): Promise<Record<string, ModListSubscribeRequest['action']>> {
-  const keys = Object.keys(localStorage)
-  const modListIds = keys.filter((key) => key.startsWith('rxliuli:modlist:'))
-  const subscriptions = modListIds.reduce((acc, key) => {
-    const modListId = key.split(':')[2]
-    const action = localStorage.getItem(key) as ModListSubscribeRequest['action']
-    acc[modListId] = action
-    return acc
-  }, {} as Record<string, ModListSubscribeRequest['action']>)
-  return subscriptions
+  const allEntries = await entries();
+  const subscriptions = allEntries.reduce((acc, [key, value]) => {
+    if (typeof key === 'string' && key.startsWith('rxliuli:modlist:')) {
+      const modListId = key.split(':')[2];
+      acc[modListId] = value as ModListSubscribeRequest['action'];
+    }
+    return acc;
+  }, {} as Record<string, ModListSubscribeRequest['action']>);
+  return subscriptions;
 }

--- a/packages/plugin/src/lib/localModlistSubscriptions.ts
+++ b/packages/plugin/src/lib/localModlistSubscriptions.ts
@@ -1,0 +1,26 @@
+import { ModListSubscribeRequest } from "@mass-block-twitter/server";
+
+
+
+export async function setSubscription(modListId: string, action: ModListSubscribeRequest['action']) {
+  localStorage.setItem(`rxliuli:modlist:${modListId}:action`, action)
+}
+export async function removeSubscription(modListId: string) {
+  localStorage.removeItem(`rxliuli:modlist:${modListId}:action`)
+}
+
+export async function getSubscription(modListId: string): Promise<ModListSubscribeRequest['action'] | null> {
+  return localStorage.getItem(`rxliuli:modlist:${modListId}:action`) as ModListSubscribeRequest['action'] | null
+}
+
+export async function getAllSubscriptions(): Promise<Record<string, ModListSubscribeRequest['action']>> {
+  const keys = Object.keys(localStorage)
+  const modListIds = keys.filter((key) => key.startsWith('rxliuli:modlist:'))
+  const subscriptions = modListIds.reduce((acc, key) => {
+    const modListId = key.split(':')[2]
+    const action = localStorage.getItem(key) as ModListSubscribeRequest['action']
+    acc[modListId] = action
+    return acc
+  }, {} as Record<string, ModListSubscribeRequest['action']>)
+  return subscriptions
+}

--- a/packages/server/src/lib.d.ts
+++ b/packages/server/src/lib.d.ts
@@ -49,6 +49,7 @@ export type {
   ModListUpdateRuleResponse,
   ModListAddTwitterUsersResponse,
   ModListAddTwitterUsersRequest,
+  ModListIdsResponse,
 } from './routes/modlists'
 export type { CheckoutCompleteRequest } from './routes/billing'
 export type {

--- a/packages/server/src/middlewares/auth.ts
+++ b/packages/server/src/middlewares/auth.ts
@@ -32,7 +32,10 @@ export async function generateToken(
 
 export function auth(): MiddlewareHandler<HonoEnv> {
   return async (c, next) => {
-    if (c.req.url === '/api/modlists/search') {
+    if (
+      c.req.url === '/api/modlists/search' ||
+      c.req.url.startsWith('/api/modlists/ids/')
+    ) {
       return next()
     }
     const token = c.req.header('Authorization')?.replace('Bearer ', '')

--- a/packages/server/src/routes/modlists.ts
+++ b/packages/server/src/routes/modlists.ts
@@ -680,33 +680,6 @@ modlists.get('/subscribed/users', async (c) => {
     },
   )
 })
-export interface ModListIdsResponse {
-  twitterUserIds: string[]
-}
-
-modlists.get('/ids/:id', zValidator('param', z.object({ id: z.string() })), async (c) => {
-  const id = c.req.param('id')
-  const db = drizzle(c.env.DB)
-  
-  const _modList = await db
-    .select()
-    .from(modList)
-    .where(eq(modList.id, id))
-    .limit(1)
-    
-  if (_modList.length === 0) {
-    return c.json({ code: 'modListNotFound' }, 404)
-  }
-  
-  const users = await db
-    .select({ twitterUserId: modListUser.twitterUserId })
-    .from(modListUser)
-    .where(eq(modListUser.modListId, id))
-    
-  return c.json<ModListIdsResponse>({ twitterUserIds: users.map(u => u.twitterUserId) })
-})
-
-
 
 const searchSchema = z.object({
   cursor: z.string().optional(),
@@ -869,6 +842,37 @@ search.get('/rules', zValidator('query', rulesSchema), async (c) => {
     cursor: rules.length === limit ? rules[rules.length - 1]?.id : undefined,
   })
 })
+
+export interface ModListIdsResponse {
+  twitterUserIds: string[]
+}
+search.get(
+  '/ids/:id',
+  zValidator('param', z.object({ id: z.string() })),
+  async (c) => {
+    const id = c.req.param('id')
+    const db = drizzle(c.env.DB)
+
+    const _modList = await db
+      .select()
+      .from(modList)
+      .where(eq(modList.id, id))
+      .limit(1)
+
+    if (_modList.length === 0) {
+      return c.json({ code: 'modListNotFound' }, 404)
+    }
+
+    const users = await db
+      .select({ twitterUserId: modListUser.twitterUserId })
+      .from(modListUser)
+      .where(eq(modListUser.modListId, id))
+
+    return c.json<ModListIdsResponse>({
+      twitterUserIds: users.map((u) => u.twitterUserId),
+    })
+  },
+)
 
 export { modlists, search as modlistSearch }
 export type { ModListConditionItem } from '../db/schema'

--- a/packages/server/src/routes/modlists.ts
+++ b/packages/server/src/routes/modlists.ts
@@ -680,6 +680,33 @@ modlists.get('/subscribed/users', async (c) => {
     },
   )
 })
+export interface ModListIdsResponse {
+  twitterUserIds: string[]
+}
+
+modlists.get('/ids/:id', zValidator('param', z.object({ id: z.string() })), async (c) => {
+  const id = c.req.param('id')
+  const db = drizzle(c.env.DB)
+  
+  const _modList = await db
+    .select()
+    .from(modList)
+    .where(eq(modList.id, id))
+    .limit(1)
+    
+  if (_modList.length === 0) {
+    return c.json({ code: 'modListNotFound' }, 404)
+  }
+  
+  const users = await db
+    .select({ twitterUserId: modListUser.twitterUserId })
+    .from(modListUser)
+    .where(eq(modListUser.modListId, id))
+    
+  return c.json<ModListIdsResponse>({ twitterUserIds: users.map(u => u.twitterUserId) })
+})
+
+
 
 const searchSchema = z.object({
   cursor: z.string().optional(),

--- a/packages/server/test/modlists.test.ts
+++ b/packages/server/test/modlists.test.ts
@@ -23,6 +23,7 @@ import type {
   ModListUpdateRuleResponse,
   ModListAddTwitterUsersRequest,
   ModListAddTwitterUsersResponse,
+  ModListIdsResponse,
 } from '../src/lib'
 import { TwitterUser } from '../src/routes/twitter'
 import { initCloudflareTest } from './utils'
@@ -760,6 +761,27 @@ describe('modlists', () => {
       expect(r2.length).toBe(2)
       expect(r2[0].id).toBe('twitter-user-1')
       expect(r2[1].id).toBe('twitter-user-2')
+    })
+    it('should be able to get ids', async () => {
+      await addUserToModList(
+        {
+          id: 'twitter-user-1',
+          screen_name: 'test-user-1',
+          name: 'test-user-1',
+          created_at: new Date().toISOString(),
+          is_blue_verified: false,
+          followers_count: 100,
+          friends_count: 100,
+          default_profile: false,
+          default_profile_image: false,
+        },
+        modListId,
+      )
+      const resp1 = await fetch(`/api/modlists/ids/${modListId}`)
+      expect(resp1.ok).true
+      const r1 = (await resp1.json()) as ModListIdsResponse
+      expect(r1.twitterUserIds).length(1)
+      expect(r1.twitterUserIds[0]).toBe('twitter-user-1')
     })
   })
   describe('rule', () => {


### PR DESCRIPTION
this is missing:
- respecting rules
- handling logged out->logged in transition (should we upload the local modlists? or just ignore the local stuff?)
- handling logged in->logged out (actually, this isn't being handled currently, and the existing blocked users ids are kept in storage)