### PR TITLE
feat(plugin): ModlistAddUser show the time of rate limit reset in toast

### DIFF
--- a/packages/plugin/src/entrypoints/content/pages/modlists/detail/components/ModlistAddUser.svelte
+++ b/packages/plugin/src/entrypoints/content/pages/modlists/detail/components/ModlistAddUser.svelte
@@ -37,7 +37,7 @@
   import { Input } from '$lib/components/ui/input'
   import { ThreeCheckbox } from '$lib/components/custom/checkbox'
   import { untrack } from 'svelte'
-  import { t } from '$lib/i18n'
+  import { t, tP } from '$lib/i18n'
   import { refreshModListSubscribedUsers } from '$lib/content'
 
   let {
@@ -80,7 +80,9 @@
         })
       } catch (err) {
         if (err instanceof Response && err.status === 429) {
-          toast.error($t('modlists.addUser.error.rateLimit'))
+          const rateLimitReset = err.headers.get('x-rate-limit-reset');
+          const resetTime = rateLimitReset ? new Date(parseInt(rateLimitReset, 10) * 1000).toLocaleTimeString() : null;
+          toast.error(tP(`modlists.addUser.error.${resetTime ? 'rateLimitTime' : 'rateLimit'}`, { values: { resetTime } }))
         }
         throw err
       }

--- a/packages/plugin/src/i18n/en-US.json
+++ b/packages/plugin/src/i18n/en-US.json
@@ -303,6 +303,7 @@
   "modlists.addUser.toast.addFailed": "Add to list failed",
   "modlists.addUser.toast.removeFailed": "Failed to remove user",
   "modlists.addUser.error.rateLimit": "Rate limit exceeded, please try again later",
+  "modlists.addUser.error.rateLimitTime": "Rate limit exceeded, try again after {resetTime}",
   "modlists.addUser.error.searchFailed": "Failed to search users",
   "modlists.created.title": "My Moderation Lists",
   "modlists.subscribed.title": "Subscribed Moderation Lists",

--- a/packages/plugin/src/i18n/es.json
+++ b/packages/plugin/src/i18n/es.json
@@ -291,6 +291,7 @@
   "modlists.addUser.toast.addFailed": "Error al agregar a la lista",
   "modlists.addUser.toast.removeFailed": "Error al eliminar usuario",
   "modlists.addUser.error.rateLimit": "Límite de tasa excedido, intentá más tarde",
+  "modlists.addUser.error.rateLimitTime": "Límite de tasa excedido, intentá de nuevo después de {resetTime}",
   "modlists.addUser.error.searchFailed": "Error al buscar usuarios",
   "modlists.created.title": "Mis Listas de Moderación",
   "modlists.subscribed.title": "Listas de Moderación Suscritas",

--- a/packages/plugin/src/i18n/fa-IR.json
+++ b/packages/plugin/src/i18n/fa-IR.json
@@ -303,6 +303,7 @@
   "modlists.addUser.toast.addFailed": "افزودن به فهرست ناموفق بود",
   "modlists.addUser.toast.removeFailed": "حذف کاربر ناموفق بود",
   "modlists.addUser.error.rateLimit": "محدودیت نرخ تجاوز کرد، لطفاً بعداً دوباره تلاش کنید",
+  "modlists.addUser.error.rateLimitTime": "محدودیت نرخ تجاوز کرد، لطفاً بعد {resetTime} دوباره تلاش کنید",
   "modlists.addUser.error.searchFailed": "جستجوی کاربران ناموفق بود",
   "modlists.created.title": "فهرست‌های تعدیل من",
   "modlists.subscribed.title": "فهرست‌های تعدیل مشترک شده",

--- a/packages/plugin/src/i18n/zh-CN.json
+++ b/packages/plugin/src/i18n/zh-CN.json
@@ -274,6 +274,7 @@
   "modlists.addUser.toast.addFailed": "添加到列表失败",
   "modlists.addUser.toast.removeFailed": "移除用户失败",
   "modlists.addUser.error.rateLimit": "已达到速率限制，请稍后再试",
+  "modlists.addUser.error.rateLimitTime": "已达到速率限制，请在 {resetTime} 后再试",
   "modlists.addUser.error.searchFailed": "搜索用户失败",
   "modlists.created.title": "我的审核列表",
   "modlists.subscribed.title": "已订阅的审核列表",


### PR DESCRIPTION
Currently toasts only tell the user to "try later" when they exceed the rate limit, but twitter returns the time of when their rate limit is reset in the `x-rate-limit-reset` header, we can show that to the user.

<img width="398" height="125" alt="image" src="https://github.com/user-attachments/assets/f4501a51-4fc7-4b3b-94a0-54be12e3828f" />
