### PR TITLE
Feat: move quick block button next to the top Grok button

### DIFF
--- a/packages/plugin/src/entrypoints/style.css
+++ b/packages/plugin/src/entrypoints/style.css
@@ -12,18 +12,27 @@
   appearance: none;
 
   box-sizing: border-box;
-  width: 38.5px;
-  height: 38.5px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.mass-block-twitter-button-block:hover {
+.mass-block-twitter-button-block:hover::before{
+  opacity: 1;
+}
+.mass-block-twitter-button-block::before{
+  content: '';
+  position: absolute;
+  width: 35px;
+  height: 35px;
   background-color: rgba(249, 24, 128, 0.1);
+  border-radius: 50%;
+  z-index: -1;
+  opacity: 0;
+  transition: opacity 0.2s;
 }
 .mass-block-twitter-button-block svg {
-  stroke: rgb(113, 118, 123);
+  stroke: inherit;
 }
 .mass-block-twitter-button-block:hover svg {
   stroke: rgb(249, 24, 128);

--- a/packages/plugin/src/lib/observe.ts
+++ b/packages/plugin/src/lib/observe.ts
@@ -57,18 +57,21 @@ export function addBlockButtonInTweet(tweetElement: HTMLElement) {
   if (tweetElement.dataset.quickBlockAdded === 'true') {
     return
   }
-  const actionBar = tweetElement.querySelector('[role="group"]')
+  const actionBar = tweetElement.querySelector('div:has(>button[aria-label*="Grok"])')
   if (!actionBar) {
     return
   }
   const customButton = document.createElement('button')
-  customButton.style.height = getComputedStyle(actionBar).height
   customButton.className = 'mass-block-twitter-button-block'
   customButton.title = 'Quick Block'
   customButton.style.opacity = '0'
   customButton.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield-ban"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m4.243 5.21 14.39 12.472"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield-ban"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m4.243 5.21 14.39 12.472"/></svg>
     `
+  const grokSvg = tweetElement.querySelector('button[aria-label*="Grok"] svg')
+  if (grokSvg) {
+    customButton.style.stroke = getComputedStyle(grokSvg).color
+  }
   customButton.addEventListener('click', async () => {
     const { tweetId } = extractTweet(tweetElement)
     const tweet = await dbApi.tweets.get(tweetId)
@@ -97,7 +100,7 @@ export function addBlockButtonInTweet(tweetElement: HTMLElement) {
       tweet,
     })
   })
-  actionBar.appendChild(customButton)
+  actionBar.after(customButton)
   tweetElement.dataset.quickBlockAdded = 'true'
   requestAnimationFrame(() => {
     customButton.style.opacity = '1'


### PR DESCRIPTION
Move quick block button next to the top Grok button.

<img width="1920" height="879" alt="image" src="https://github.com/user-attachments/assets/9d08112f-4ddd-458a-9c00-b42e73910e1d" />

I haven't found any mobile compatibility issues after moving, if you find any, I will try to fix it.

https://discord.com/channels/1371251680787824650/1489520230316118046